### PR TITLE
``python setup.py egg_info`` should work without the dependencies installed

### DIFF
--- a/sdpy/__init__.py
+++ b/sdpy/__init__.py
@@ -1,6 +1,9 @@
-from . import makecube
-from . import make_off_template
-from . import calibrate_map_scans
-from .makecube import make_flats,add_file_to_cube,make_taucube
-from .make_off_template import make_off
-from .calibrate_map_scans import calibrate_cube_data
+from ._astropy_init import *
+
+if not _ASTROPY_SETUP:
+    from . import makecube
+    from . import make_off_template
+    from . import calibrate_map_scans
+    from .makecube import make_flats,add_file_to_cube,make_taucube
+    from .make_off_template import make_off
+    from .calibrate_map_scans import calibrate_cube_data


### PR DESCRIPTION
As far as I understand this should work, but the test fail on travis. If this is not the case for ``sdpy``, then the test run should be removed from the ``.travis.yml`` file.

```
Could not locate requirements.txt. Override the install: key in your .travis.yml to install dependencies.
0.48s$ python setup.py $SETUP_CMD
Traceback (most recent call last):
  File "setup.py", line 37, in <module>
    __import__(PACKAGENAME)
  File "/home/travis/build/keflavich/sdpy/sdpy/__init__.py", line 1, in <module>
    from . import makecube
  File "/home/travis/build/keflavich/sdpy/sdpy/makecube.py", line 6, in <module>
    import pyfits
ImportError: No module named pyfits
```